### PR TITLE
chore: update devx environment

### DIFF
--- a/Dockerfile.devx
+++ b/Dockerfile.devx
@@ -1,4 +1,4 @@
-FROM leadiv/breakingnews-vue:latest
+FROM leadiv/breakingnews-vue:develop
 MAINTAINER Paul Borrego <paul.borrego@turner.com>
 
 ENV HOME=/home/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,9 @@ services:
       - NODE_ENV=testing
       - API_INTERVAL=120000
       - API_URL=http://dataref.cnn.com/breaking_news/domestic.json
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile.devx
     command: ['npm', 'run', 'unit:watch']
     user: root
     volumes:


### PR DESCRIPTION
Update the devx environment to pull from the develop tag. Since this is the bleeding edge of the project. Also updated the testing container to pull from Dockerfile.devx instead of the Dockerfile. This way npm install isn't ran while working with the development environment.