### PR TITLE
feat: update main to vue plugin

### DIFF
--- a/build/webpack.dev.conf.js
+++ b/build/webpack.dev.conf.js
@@ -29,7 +29,7 @@ module.exports = merge(baseWebpackConfig, {
     new HtmlWebpackPlugin({
       filename: 'index.html',
       template: 'index.html',
-      inject: true
+      inject: 'head'
     }),
     new FriendlyErrors()
   ]

--- a/index.html
+++ b/index.html
@@ -3,9 +3,17 @@
   <head>
     <meta charset="utf-8">
     <title>breakingnews-vue</title>
+    <script src="https://unpkg.com/vue/dist/vue.js"></script>
+    <!-- built files will be auto injected -->
   </head>
   <body>
-    <div id="app-goes-here"></div>
-    <!-- built files will be auto injected -->
+    <div id="mount">
+      <breaking-news-banner api="/static/api.mock.json"></breaking-news-banner>
+    </div>
+    <script>
+      new Vue({
+        el: '#mount'
+      });
+    </script>
   </body>
 </html>

--- a/src/components/breaking-news-banner/index.vue
+++ b/src/components/breaking-news-banner/index.vue
@@ -14,7 +14,7 @@ import BreakingNews from '../breaking-news';
 import FetchData from '../fetch-data';
 
 export default {
-    name: 'app',
+    name: 'breaking-news-banner',
     props: {
         api: {
             type: String,

--- a/src/main.js
+++ b/src/main.js
@@ -1,13 +1,28 @@
-import Vue from 'vue';
-import App from './components/app';
+/* global window global */
+import BreakingNewsBanner from './components/breaking-news-banner';
 
-const props = {
-    api: process.env.API_URL,
-    interval: parseInt(process.env.API_INTERVAL, 10),
+// Install the components
+export function install(Vue) {
+    Vue.component('breaking-news-banner', BreakingNewsBanner);
+}
+
+// Expose the components
+export {
+    BreakingNewsBanner,
 };
 
-/* eslint-disable no-new */
-new Vue({
-    el: '#app-goes-here',
-    render: h => h(App, { props }),
-});
+// Plugin
+const plugin = {
+    install,
+};
+
+// Auto-install
+const GlobalVue = (typeof window !== 'undefined' && window.Vue) ||
+                  (typeof global !== 'undefined' && global.Vue) ||
+                  null;
+
+if (GlobalVue) {
+    GlobalVue.use(plugin);
+}
+
+export default plugin;


### PR DESCRIPTION
Updates main.js so that the component can be distributed as a plugin. This makes it easier for developers consuming the library to just use the component as is.